### PR TITLE
fix autocrafter gamerule check (partially fix #4)

### DIFF
--- a/core/src/main/java/io/github/thebusybiscuit/slimefun5/implementation/listeners/AutoCrafterListener.java
+++ b/core/src/main/java/io/github/thebusybiscuit/slimefun5/implementation/listeners/AutoCrafterListener.java
@@ -70,10 +70,10 @@ public class AutoCrafterListener implements Listener {
                 // Prevent blocks from being placed, food from being eaten, etc...
                 e.cancel();
 
-                // Check for the "doLimitedCrafting" gamerule when using a Vanilla Auto-Crafter
+                // Check for the "limited_crafting" gamerule when using a Vanilla Auto-Crafter
                 if (block instanceof VanillaAutoCrafter) {
                     // GameRule<T> typed accessor is 1.13+; the deprecated String overload exists on 1.8.
-                    boolean doLimitedCrafting = Boolean.parseBoolean(e.getPlayer().getWorld().getGameRuleValue("doLimitedCrafting"));
+                    boolean doLimitedCrafting = Boolean.parseBoolean(e.getPlayer().getWorld().getGameRuleValue("limited_crafting"));
 
                     // Check if the recipe of the item is disabled.
                     if (doLimitedCrafting && !hasUnlockedRecipe(e.getPlayer(), e.getItem())) {


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
fixes one part of #4 by using the correct modern gamerule naming
## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
replaced `"doLimitedCrafting"` with `limited_crafting` for 1.21.11+ syntax
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves one part of #004 (not completely resolved though)
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.21.*).
- - don't you mean 26.1.2 according to the readme?
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
